### PR TITLE
Fix shortcut disabling not working on Mac

### DIFF
--- a/src/options/advanced/DisableShortcuts.ts
+++ b/src/options/advanced/DisableShortcuts.ts
@@ -21,13 +21,13 @@ module DisableShortcuts {
 	$(document).on('keydown', function(e) {
 		if(!enabled) return;
 
-		// Ctrl Hotkeys
-		if(e.ctrlKey) {
+		// Ctrl / Meta Hotkeys
+		if(e.ctrlKey || e.metaKey) {
 			
-			// Ctrl+0 (Zoom Reset)
+			// Ctrl+0 / Meta+0 (Zoom Reset)
 			if(e.keyCode == 48) e.preventDefault();
 
-			// Ctrl+[1-9] (Switch Tabs)
+			// Ctrl+[1-9] / Meta+[1-9] (Switch Tabs)
 			if(e.keyCode >= 49 && e.keyCode <= 57) e.preventDefault();
 		}
 


### PR DESCRIPTION
Since Mac uses the command/meta key for shortcuts, the shortcut disabling feature does not work on Mac as it checks for the control key rather than the command/meta key. This pull request updates the shortcut disabling feature's logic so that it checks for the command/meta key in addition to the control key when looking for keyboard events to cancel.